### PR TITLE
fix: raise EFBChatNotFound instead return None if chat is not found

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -24,7 +24,7 @@ from . import __version__ as version
 from ehforwarderbot.channel import SlaveChannel
 from ehforwarderbot.types import MessageID, ChatID, InstanceID
 from ehforwarderbot import utils as efb_utils
-from ehforwarderbot.exceptions import EFBException
+from ehforwarderbot.exceptions import EFBException, EFBChatNotFound
 from ehforwarderbot.message import MessageCommand, MessageCommands
 from ehforwarderbot.status import MessageRemoval
 
@@ -598,6 +598,7 @@ class ComWeChatChannel(SlaveChannel):
             for friend in self.friends:
                 if friend.uid == chat_uid:
                     return friend
+        raise EFBChatNotFound
 
     #发送消息
     def send_message(self, msg : Message) -> Message:


### PR DESCRIPTION
![PixPin_2025-05-14_10-27-45](https://github.com/user-attachments/assets/4044402f-8f3e-4e6c-865e-aacd06319df9)

根据 ehforwarderbot 框架要求，需要正确抛出错误，否则在其他端会出现异常