### PR TITLE
fix: fix escaped text unmatched

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import re
 import json
 from ehforwarderbot.chat import SystemChat, PrivateChat , SystemChatMember, ChatMember, SelfChatMember
+import hashlib
 from typing import Tuple, Optional, Collection, BinaryIO, Dict, Any , Union , List
 from datetime import datetime
 from cachetools import TTLCache
@@ -609,7 +610,7 @@ class ComWeChatChannel(SlaveChannel):
         if msg.text:
             match = re.search(self.forward_pattern, msg.text)
             if match:
-                if match.group(1) == self.channel_id:
+                if match.group(1) == hashlib.md5(self.channel_id.encode('utf-8')).hexdigest():
                     msgid = match.group(2)
                     self.logger.debug(f"提取到的消息 ID: {msgid}")
                     self.bot.ForwardMessage(wxid = chat_uid, msgid = msgid)
@@ -686,7 +687,7 @@ class ComWeChatChannel(SlaveChannel):
                 if isinstance(msg.target, Message):
                     msgid = msg.target.uid
                     if msgid.isdecimal():
-                        url = f"ehforwarderbot://{self.channel_id}/forward/{msgid}"
+                        url = f"ehforwarderbot://{hashlib.md5(self.channel_id.encode('utf-8')).hexdigest()}/forward/{msgid}"
                         prompt = "请将这条信息转发到目标聊天中"
                         text = f"{url}\n{prompt}"
                         if msg.target.text:


### PR DESCRIPTION
[efb-telegram-master](https://github.com/ehForwarderBot/efb-telegram-master/blob/0850aeb294260c3cc14d382991837f99e12fae8c/efb_telegram_master/master_message.py#L282-L292) 会转义部分特殊字符，在此例中是 `.`，导致匹配失败。改为比较 hash 字符串以规避转义问题