### PR TITLE
fix: fix quote message campatibility

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -115,7 +115,7 @@ QUOTE_MESSAGE="""<msg>
             <type>1</type>
             <svrid>%s</svrid>
             <fromusr>%s</fromusr>
-            <chatusr />
+            <chatusr>%s</chatusr>
             <displayname>%s</displayname>
             <content>%s</content>
         </refermsg>
@@ -896,12 +896,12 @@ class ComWeChatChannel(SlaveChannel):
                 else:
                     msgid = msg.target.uid
                     sender = msg.target.author.uid
-                    displayname = msg.target.author.display_name
+                    displayname = msg.target.author.name
                     content = escape(msg.target.vendor_specific.get("wx_xml", ""))
                     if "@chatroom" in msg.author.chat.uid:
                         xml = QUOTE_GROUP_MESSAGE % (self.wxid, text, msgid, sender, msg.author.chat.uid, displayname, content)
                     else:
-                        xml = QUOTE_MESSAGE % (self.wxid, text, msgid, sender, displayname, content)
+                        xml = QUOTE_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
                     return self.bot.SendXml(wxid = wxid , xml = xml, img_path = "")
         return self.bot.SendText(wxid = wxid , msg = text)
 

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -796,6 +796,10 @@ class ComWeChatChannel(SlaveChannel):
                     sender = msg.target.author.uid
                     displayname = msg.target.author.name
                     content = escape(msg.target.vendor_specific.get("wx_xml", ""))
+                    if content:
+                        content = "<content>%s</content>" % content
+                    else:
+                        content = "<content />"
                     if "@chatroom" in msg.author.chat.uid:
                         xml = QUOTE_GROUP_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
                     else:

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -797,7 +797,7 @@ class ComWeChatChannel(SlaveChannel):
                     displayname = msg.target.author.name
                     content = escape(msg.target.vendor_specific.get("wx_xml", ""))
                     if "@chatroom" in msg.author.chat.uid:
-                        xml = QUOTE_GROUP_MESSAGE % (self.wxid, text, msgid, sender, msg.author.chat.uid, displayname, content)
+                        xml = QUOTE_GROUP_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
                     else:
                         xml = QUOTE_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
                     return self.bot.SendXml(wxid = wxid , xml = xml, img_path = "")

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -32,7 +32,7 @@ from ehforwarderbot.status import MessageRemoval
 from .ChatMgr import ChatMgr
 from .CustomTypes import EFBGroupChat, EFBPrivateChat, EFBGroupMember, EFBSystemUser
 from .MsgDeco import qutoed_text
-from .MsgProcess import MsgProcess
+from .MsgProcess import MsgProcess, MsgWrapper
 from .Utils import download_file , load_config , load_temp_file_to_local , WC_EMOTICON_CONVERSION
 
 from rich.console import Console
@@ -501,7 +501,7 @@ class ComWeChatChannel(SlaveChannel):
             self.file_msg[msg["filepath"]] = ( msg , author , chat )
             return
 
-        self.send_efb_msgs(MsgProcess(msg, chat), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
+        self.send_efb_msgs(MsgWrapper(msg["message"], MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
 
     def handle_file_msg(self):
         while True:
@@ -533,7 +533,7 @@ class ComWeChatChannel(SlaveChannel):
 
                     if flag:
                         del self.file_msg[path]
-                        self.send_efb_msgs(MsgProcess(msg, chat), author=author, chat=chat, uid=msg['msgid'])
+                        self.send_efb_msgs(MsgWrapper(msg["message"], MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
 
             if len(self.delete_file):
                 for k in list(self.delete_file.keys()):

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -35,115 +35,13 @@ from .CustomTypes import EFBGroupChat, EFBPrivateChat, EFBGroupMember, EFBSystem
 from .MsgDeco import qutoed_text
 from .MsgProcess import MsgProcess, MsgWrapper
 from .Utils import download_file , load_config , load_temp_file_to_local , WC_EMOTICON_CONVERSION
+from .Constant import QUOTE_MESSAGE, QUOTE_GROUP_MESSAGE
 
 from rich.console import Console
 from rich import print as rprint
 from io import BytesIO
 from PIL import Image
 from pyqrcode import QRCode
-
-QUOTE_GROUP_MESSAGE="""<msg>
-    <fromusername>%s</fromusername>
-    <scene>0</scene>
-    <commenturl></commenturl>
-    <appmsg appid="" sdkver="0">
-        <title>%s</title>
-        <des></des>
-        <action>view</action>
-        <type>57</type>
-        <showtype>0</showtype>
-        <content></content>
-        <url></url>
-        <dataurl></dataurl>
-        <lowurl></lowurl>
-        <lowdataurl></lowdataurl>
-        <recorditem></recorditem>
-        <thumburl></thumburl>
-        <messageaction></messageaction>
-        <refermsg>
-            <type>1</type>
-            <svrid>%s</svrid>
-            <fromusr>%s</fromusr>
-            <chatusr>%s</chatusr>
-            <displayname>%s</displayname>
-            <content>%s</content>
-        </refermsg>
-        <extinfo></extinfo>
-        <sourceusername></sourceusername>
-        <sourcedisplayname></sourcedisplayname>
-        <commenturl></commenturl>
-        <appattach>
-            <totallen>0</totallen>
-            <attachid></attachid>
-            <emoticonmd5></emoticonmd5>
-            <fileext></fileext>
-            <aeskey></aeskey>
-        </appattach>
-        <weappinfo>
-            <pagepath></pagepath>
-            <username></username>
-            <appid></appid>
-            <appservicetype>0</appservicetype>
-        </weappinfo>
-        <websearch />
-    </appmsg>
-    <appinfo>
-        <version>1</version>
-        <appname>Window wechat</appname>
-    </appinfo>
-</msg>
-"""
-QUOTE_MESSAGE="""<msg>
-    <fromusername>%s</fromusername>
-    <scene>0</scene>
-    <commenturl></commenturl>
-    <appmsg appid="" sdkver="0">
-        <title>%s</title>
-        <des></des>
-        <action>view</action>
-        <type>57</type>
-        <showtype>0</showtype>
-        <content></content>
-        <url></url>
-        <dataurl></dataurl>
-        <lowurl></lowurl>
-        <lowdataurl></lowdataurl>
-        <recorditem></recorditem>
-        <thumburl></thumburl>
-        <messageaction></messageaction>
-        <refermsg>
-            <type>1</type>
-            <svrid>%s</svrid>
-            <fromusr>%s</fromusr>
-            <chatusr>%s</chatusr>
-            <displayname>%s</displayname>
-            <content>%s</content>
-        </refermsg>
-        <extinfo></extinfo>
-        <sourceusername></sourceusername>
-        <sourcedisplayname></sourcedisplayname>
-        <commenturl></commenturl>
-        <appattach>
-            <totallen>0</totallen>
-            <attachid></attachid>
-            <emoticonmd5></emoticonmd5>
-            <fileext></fileext>
-            <aeskey></aeskey>
-        </appattach>
-        <weappinfo>
-            <pagepath></pagepath>
-            <username></username>
-            <appid></appid>
-            <appservicetype>0</appservicetype>
-        </weappinfo>
-        <websearch />
-    </appmsg>
-    <appinfo>
-        <version>1</version>
-        <appname>Window wechat</appname>
-    </appinfo>
-</msg>
-"""
 
 class ComWeChatChannel(SlaveChannel):
     channel_name : str = "ComWechatChannel"

--- a/efb_wechat_comwechat_slave/Constant.py
+++ b/efb_wechat_comwechat_slave/Constant.py
@@ -22,7 +22,7 @@ QUOTE_GROUP_MESSAGE="""<msg>
             <fromusr>%s</fromusr>
             <chatusr>%s</chatusr>
             <displayname>%s</displayname>
-            <content>%s</content>
+            %s
         </refermsg>
         <extinfo></extinfo>
         <sourceusername></sourceusername>
@@ -73,7 +73,7 @@ QUOTE_MESSAGE="""<msg>
             <fromusr>%s</fromusr>
             <chatusr>%s</chatusr>
             <displayname>%s</displayname>
-            <content>%s</content>
+            %s
         </refermsg>
         <extinfo></extinfo>
         <sourceusername></sourceusername>

--- a/efb_wechat_comwechat_slave/Constant.py
+++ b/efb_wechat_comwechat_slave/Constant.py
@@ -1,0 +1,102 @@
+QUOTE_GROUP_MESSAGE="""<msg>
+    <fromusername>%s</fromusername>
+    <scene>0</scene>
+    <commenturl></commenturl>
+    <appmsg appid="" sdkver="0">
+        <title>%s</title>
+        <des></des>
+        <action>view</action>
+        <type>57</type>
+        <showtype>0</showtype>
+        <content></content>
+        <url></url>
+        <dataurl></dataurl>
+        <lowurl></lowurl>
+        <lowdataurl></lowdataurl>
+        <recorditem></recorditem>
+        <thumburl></thumburl>
+        <messageaction></messageaction>
+        <refermsg>
+            <type>1</type>
+            <svrid>%s</svrid>
+            <fromusr>%s</fromusr>
+            <chatusr>%s</chatusr>
+            <displayname>%s</displayname>
+            <content>%s</content>
+        </refermsg>
+        <extinfo></extinfo>
+        <sourceusername></sourceusername>
+        <sourcedisplayname></sourcedisplayname>
+        <commenturl></commenturl>
+        <appattach>
+            <totallen>0</totallen>
+            <attachid></attachid>
+            <emoticonmd5></emoticonmd5>
+            <fileext></fileext>
+            <aeskey></aeskey>
+        </appattach>
+        <weappinfo>
+            <pagepath></pagepath>
+            <username></username>
+            <appid></appid>
+            <appservicetype>0</appservicetype>
+        </weappinfo>
+        <websearch />
+    </appmsg>
+    <appinfo>
+        <version>1</version>
+        <appname>Window wechat</appname>
+    </appinfo>
+</msg>
+"""
+QUOTE_MESSAGE="""<msg>
+    <fromusername>%s</fromusername>
+    <scene>0</scene>
+    <commenturl></commenturl>
+    <appmsg appid="" sdkver="0">
+        <title>%s</title>
+        <des></des>
+        <action>view</action>
+        <type>57</type>
+        <showtype>0</showtype>
+        <content></content>
+        <url></url>
+        <dataurl></dataurl>
+        <lowurl></lowurl>
+        <lowdataurl></lowdataurl>
+        <recorditem></recorditem>
+        <thumburl></thumburl>
+        <messageaction></messageaction>
+        <refermsg>
+            <type>1</type>
+            <svrid>%s</svrid>
+            <fromusr>%s</fromusr>
+            <chatusr>%s</chatusr>
+            <displayname>%s</displayname>
+            <content>%s</content>
+        </refermsg>
+        <extinfo></extinfo>
+        <sourceusername></sourceusername>
+        <sourcedisplayname></sourcedisplayname>
+        <commenturl></commenturl>
+        <appattach>
+            <totallen>0</totallen>
+            <attachid></attachid>
+            <emoticonmd5></emoticonmd5>
+            <fileext></fileext>
+            <aeskey></aeskey>
+        </appattach>
+        <weappinfo>
+            <pagepath></pagepath>
+            <username></username>
+            <appid></appid>
+            <appservicetype>0</appservicetype>
+        </weappinfo>
+        <websearch />
+    </appmsg>
+    <appinfo>
+        <version>1</version>
+        <appname>Window wechat</appname>
+    </appinfo>
+</msg>
+"""

--- a/efb_wechat_comwechat_slave/MsgProcess.py
+++ b/efb_wechat_comwechat_slave/MsgProcess.py
@@ -12,6 +12,16 @@ from lxml import etree
 from ehforwarderbot import utils as efb_utils
 from ehforwarderbot.message import Message
 
+def MsgWrapper(xml, efb_msgs:  Union[Message, List[Message]]):
+    efb_msgs = [efb_msgs] if isinstance(efb_msgs, Message) else efb_msgs
+    if not efb_msgs:
+        return
+    for efb_msg in efb_msgs:
+        vendor_specific = getattr(efb_msg, "vendor_specific", {})
+        vendor_specific["wx_xml"] = xml
+        setattr(efb_msg, "vendor_specific", vendor_specific)
+    return efb_msgs
+
 def MsgProcess(msg : dict , chat) -> Union[Message, List[Message]]:
 
     if msg["type"] == "text":


### PR DESCRIPTION
微信在电脑端存在 bug，不同版本对引用消息的处理逻辑存在区别。同一条消息的显示效果可能会存在如下区别：

mac Version. 3.6.1 (24207):

<img width="1440" height="456" alt="PixPin_2025-07-15_15-09-25" src="https://github.com/user-attachments/assets/df72c93a-eb5e-4e4a-8bb5-777e84cb2372" />

mac Version 3.8.10 (28633):

<img width="1516" height="520" alt="PixPin_2025-07-15_15-10-35" src="https://github.com/user-attachments/assets/19b854e2-c37d-4d72-b08b-1f146a282dbf" />

mac Version 4.0.6.19:

<img width="1388" height="388" alt="PixPin_2025-07-15_15-12-14" src="https://github.com/user-attachments/assets/e1c869d6-6f0b-4a87-ac34-8a55a0f61be2" />

现在将引用消息的 发送人名称，和 xml 文本传入以保证兼容性

xml 文本的获取依赖于 etm 数据库存储 vendor_specific 字段，依赖于这个 [pr](https://github.com/ehForwarderBot/efb-telegram-master/pull/149)